### PR TITLE
Fix bug causing build to hang if build.xml exists

### DIFF
--- a/src/main/java/com/palantir/gradle/circlestyle/CircleStylePlugin.java
+++ b/src/main/java/com/palantir/gradle/circlestyle/CircleStylePlugin.java
@@ -65,7 +65,7 @@ public class CircleStylePlugin implements Plugin<Project> {
         int attemptNumber = 1;
         File targetFile = new File(new File(circleReportsDir, "gradle"), "build.xml");
         while (targetFile.exists()) {
-            targetFile = new File(new File(circleReportsDir, "gradle"), "build" + attemptNumber + ".xml");
+            targetFile = new File(new File(circleReportsDir, "gradle"), "build" + (++attemptNumber) + ".xml");
         }
         Integer container;
         try {

--- a/src/test/java/com/palantir/gradle/circlestyle/CircleStylePluginTests.java
+++ b/src/test/java/com/palantir/gradle/circlestyle/CircleStylePluginTests.java
@@ -18,6 +18,7 @@ package com.palantir.gradle.circlestyle;
 import static com.google.common.base.Charsets.UTF_8;
 import static com.palantir.gradle.circlestyle.TestCommon.copyTestFile;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
@@ -97,6 +98,24 @@ public class CircleStylePluginTests {
         assertThat(result.getOutput()).contains("This task will always fail");
 
         File report = new File(reportsDir, "gradle/build.xml");
+        assertThat(report).exists();
+        String reportXml = Files.asCharSource(report, UTF_8).read();
+        assertThat(reportXml).contains("message=\"RuntimeException: This task will always fail\"");
+    }
+
+    @Test
+    public void findsUniqueBuildStepsReportFileName() throws IOException {
+        assertTrue(new File(reportsDir, "gradle").mkdirs());
+        assertTrue(new File(reportsDir, "gradle/build.xml").createNewFile());
+        assertTrue(new File(reportsDir, "gradle/build2.xml").createNewFile());
+
+        BuildResult result = GradleRunner.create()
+                .withProjectDir(projectDir.getRoot())
+                .withArguments("--stacktrace", "failingTask")
+                .buildAndFail();
+        assertThat(result.getOutput()).contains("This task will always fail");
+
+        File report = new File(reportsDir, "gradle/build3.xml");
         assertThat(report).exists();
         String reportXml = Files.asCharSource(report, UTF_8).read();
         assertThat(reportXml).contains("message=\"RuntimeException: This task will always fail\"");

--- a/src/test/java/com/palantir/gradle/circlestyle/CircleStylePluginTests.java
+++ b/src/test/java/com/palantir/gradle/circlestyle/CircleStylePluginTests.java
@@ -121,6 +121,22 @@ public class CircleStylePluginTests {
         assertThat(reportXml).contains("message=\"RuntimeException: This task will always fail\"");
     }
 
+    @Test
+    public void canCallGradleThreeTimesInARow() {
+        GradleRunner.create()
+                .withProjectDir(projectDir.getRoot())
+                .withArguments("--stacktrace", "dependencies")
+                .build();
+        GradleRunner.create()
+                .withProjectDir(projectDir.getRoot())
+                .withArguments("--stacktrace", "compileJava")
+                .build();
+        GradleRunner.create()
+                .withProjectDir(projectDir.getRoot())
+                .withArguments("--stacktrace", "compileTestJava")
+                .build();
+    }
+
     private static String pluginClasspath() {
         URLClassLoader classloader = (URLClassLoader) ClassLoader.getSystemClassLoader();
         List<String> classpath = new ArrayList<>();


### PR DESCRIPTION
This causes publish steps to fail (since build.xml will obviously already have been created), and is just down to a missing increment.

This fixes #3.