### PR TITLE
Don't rely on primary being set to true in SourceLine

### DIFF
--- a/src/main/java/com/palantir/gradle/circlestyle/FindBugsReportHandler.java
+++ b/src/main/java/com/palantir/gradle/circlestyle/FindBugsReportHandler.java
@@ -51,15 +51,18 @@ class FindBugsReportHandler extends DefaultHandler {
     private final List<Failure> failures = new ArrayList<>();
     private Failure.Builder failure = null;
     private StringBuilder content = null;
+    private int depth = 0;
 
     @Override
     public void startElement(String uri, String localName, String qName, Attributes attributes) throws SAXException {
+        depth++;
         switch (qName) {
             case "SrcDir":
                 content = new StringBuilder();
                 break;
 
             case "BugInstance":
+                depth = 0;
                 failure = new Failure.Builder()
                         .source(attributes.getValue("type"))
                         .severity("ERROR");
@@ -67,9 +70,10 @@ class FindBugsReportHandler extends DefaultHandler {
 
             case "LongMessage":
                 content = new StringBuilder();
+                break;
 
             case "SourceLine":
-                if ("true".equals(attributes.getValue("primary"))) {
+                if (depth == 1) {
                     String sourcepath = attributes.getValue("sourcepath");
                     File sourceFile = new File(sourcepath);
                     for (String source : sources) {
@@ -115,6 +119,7 @@ class FindBugsReportHandler extends DefaultHandler {
             default:
                 break;
         }
+        depth--;
     }
 
     List<Failure> failures() {

--- a/src/test/java/com/palantir/gradle/circlestyle/FindBugsReportHandlerTests.java
+++ b/src/test/java/com/palantir/gradle/circlestyle/FindBugsReportHandlerTests.java
@@ -59,4 +59,10 @@ public class FindBugsReportHandlerTests {
         List<Failure> failures = PARSER.loadFailures(testFile("two-exit-errors-findbugs.xml").openStream());
         assertThat(failures).containsExactlyElementsOf(FINDBUGS_FAILURES);
     }
+
+    /** @see <a href="https://github.com/palantir/gradle-circle-style/issues/7">Issue 7</a> */
+    @Test
+    public void testSyntheticSourceLine() throws IOException {
+        PARSER.loadFailures(testFile("synthetic-sourceline-findbugs.xml").openStream());
+    }
 }

--- a/src/test/resources/com/palantir/gradle/circlestyle/synthetic-sourceline-findbugs.xml
+++ b/src/test/resources/com/palantir/gradle/circlestyle/synthetic-sourceline-findbugs.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<BugCollection version="3.0.1" sequence="0" timestamp="1517833410853" analysisTimestamp="1517833412562" release="">
+  <BugInstance type="PT_FINAL_TYPE_PARAM" priority="2" rank="12" abbrev="PTFP" category="CORRECTNESS" instanceHash="f173d7c1ff5c0a96f539088f95577923" instanceOccurrenceNum="0" instanceOccurrenceMax="0">
+    <ShortMessage>Parameter of final type</ShortMessage>
+    <LongMessage>Parameter 0 of new com.example.Application$StatusResource(Foo, Bar, Baz) is of final type com.example.Foo</LongMessage>
+    <Int value="0">
+      <Message>Value 0</Message>
+    </Int>
+    <Class classname="com.example.Application$StatusResource" primary="true">
+      <SourceLine classname="com.example.Application$StatusResource" start="211" end="264" sourcefile="Application.java" sourcepath="com.example.Application.java">
+        <Message>At Application.java:[lines 211-264]</Message>
+      </SourceLine>
+      <Message>In class com.example.Application$StatusResource</Message>
+    </Class>
+    <Method classname="com.example.Application$StatusResource" name="&lt;init&gt;" signature="(Lcom/example/Foo;Lcom/example/Bar;Ljava/util/function/Supplier;)V" isStatic="false" primary="true">
+      <SourceLine classname="com.example.Application$StatusResource" start="218" end="222" startBytecode="0" endBytecode="125" sourcefile="Application.java" sourcepath="com.example.Application.java"/>
+      <Message>In method new com.example.Application$StatusResource(Foo, Bar, Supplier)</Message>
+    </Method>
+    <Type descriptor="Lcom/example/Foo;">
+      <SourceLine classname="com.example.Foo" start="22" end="51" sourcefile="Foo.java" sourcepath="com/example/Foo.java">
+        <Message>At Foo.java:[lines 22-51]</Message>
+      </SourceLine>
+      <Message>Type com.example.Foo</Message>
+    </Type>
+    <SourceLine classname="com.example.Application$StatusResource" start="218" end="222" startBytecode="0" endBytecode="125" sourcefile="Application.java" sourcepath="com.example.Application.java" synthetic="true">
+      <Message>At Application.java:[lines 218-222]</Message>
+    </SourceLine>
+  </BugInstance>
+  <BugInstance type="PT_FINAL_TYPE_PARAM" priority="2" rank="12" abbrev="PTFP" category="CORRECTNESS" instanceHash="8a432ef37aef9703c86b077cd7e6f252" instanceOccurrenceNum="0" instanceOccurrenceMax="0">
+    <ShortMessage>Parameter of final type</ShortMessage>
+    <LongMessage>Parameter 1 of new com.example.Application$StatusResource(Foo, Bar, Supplier) is of final type com.example.Bar</LongMessage>
+    <Int value="1">
+      <Message>Value 1</Message>
+    </Int>
+    <Class classname="com.example.Application$StatusResource" primary="true">
+      <SourceLine classname="com.example.Application$StatusResource" start="211" end="264" sourcefile="Application.java" sourcepath="com.example.Application.java">
+        <Message>At Application.java:[lines 211-264]</Message>
+      </SourceLine>
+      <Message>In class com.example.Application$StatusResource</Message>
+    </Class>
+    <Method classname="com.example.Application$StatusResource" name="&lt;init&gt;" signature="(Lcom/example/Foo;Lcom/example/Bar;Ljava/util/function/Supplier;)V" isStatic="false" primary="true">
+      <SourceLine classname="com.example.Application$StatusResource" start="218" end="222" startBytecode="0" endBytecode="125" sourcefile="Application.java" sourcepath="com.example.Application.java"/>
+      <Message>In method new com.example.Application$StatusResource(Foo, Bar, Supplier)</Message>
+    </Method>
+    <Type descriptor="Lcom/example/Bar;">
+      <SourceLine classname="com.example.Bar" start="29" end="78" sourcefile="Bar.java" sourcepath="com/example/Bar.java">
+        <Message>At Bar.java:[lines 29-78]</Message>
+      </SourceLine>
+      <Message>Type com.example.Bar</Message>
+    </Type>
+    <SourceLine classname="com.example.Application$StatusResource" start="218" end="222" startBytecode="0" endBytecode="125" sourcefile="Application.java" sourcepath="com.example.Application.java" synthetic="true">
+      <Message>At Application.java:[lines 218-222]</Message>
+    </SourceLine>
+  </BugInstance>
+</BugCollection>


### PR DESCRIPTION
It turns out that primary is not always set to true in the top-level SourceLine element; instead, we need to start tracking tree depth.

This fixes #7.