### PR TITLE
Refactor report classes

### DIFF
--- a/src/main/java/com/palantir/gradle/circlestyle/CheckstyleReportHandler.java
+++ b/src/main/java/com/palantir/gradle/circlestyle/CheckstyleReportHandler.java
@@ -16,39 +16,22 @@
 package com.palantir.gradle.circlestyle;
 
 import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.xml.parsers.ParserConfigurationException;
-import javax.xml.parsers.SAXParserFactory;
-
+import org.gradle.api.plugins.quality.Checkstyle;
 import org.xml.sax.Attributes;
-import org.xml.sax.InputSource;
-import org.xml.sax.SAXException;
-import org.xml.sax.XMLReader;
-import org.xml.sax.helpers.DefaultHandler;
 
-class CheckstyleReportHandler extends DefaultHandler {
-
-    public static ReportParser PARSER = new ReportParser() {
-        @Override
-        public List<Failure> loadFailures(InputStream report) {
-            try {
-                CheckstyleReportHandler handler = new CheckstyleReportHandler();
-                XMLReader xmlReader = SAXParserFactory.newInstance().newSAXParser().getXMLReader();
-                xmlReader.setContentHandler(handler);
-                xmlReader.parse(new InputSource(report));
-                return handler.failures();
-            } catch (SAXException | ParserConfigurationException | IOException e) {
-                throw new AssertionError(e);
-            }
-        }
-    };
+class CheckstyleReportHandler extends ReportHandler<Checkstyle> {
 
     private final List<Failure> failures = new ArrayList<>();
     private File file;
+
+    @Override
+    public void configureTask(Checkstyle task) {
+        // Ensure XML output is enabled
+        task.getReports().findByName("xml").setEnabled(true);
+    }
 
     @Override
     public void startElement(String uri, String localName, String qName, Attributes attributes) {
@@ -71,7 +54,8 @@ class CheckstyleReportHandler extends DefaultHandler {
         }
     }
 
-    List<Failure> failures() {
+    @Override
+    public List<Failure> failures() {
         return failures;
     }
 }

--- a/src/main/java/com/palantir/gradle/circlestyle/CircleStylePlugin.java
+++ b/src/main/java/com/palantir/gradle/circlestyle/CircleStylePlugin.java
@@ -15,18 +15,15 @@
  */
 package com.palantir.gradle.circlestyle;
 
+import static com.palantir.gradle.circlestyle.CircleStyleFinalizer.registerFinalizer;
+
 import java.io.File;
 
 import org.gradle.api.Action;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
-import org.gradle.api.Task;
-import org.gradle.api.UnknownTaskException;
 import org.gradle.api.plugins.quality.Checkstyle;
 import org.gradle.api.plugins.quality.FindBugs;
-import org.gradle.api.plugins.quality.FindBugsXmlReport;
-import org.gradle.api.reporting.SingleFileReport;
-import org.gradle.api.tasks.TaskContainer;
 
 public class CircleStylePlugin implements Plugin<Project> {
 
@@ -48,13 +45,23 @@ public class CircleStylePlugin implements Plugin<Project> {
                 project.getTasks().withType(Checkstyle.class, new Action<Checkstyle>() {
                     @Override
                     public void execute(Checkstyle checkstyleTask) {
-                        configureCheckstyleTask(project, checkstyleTask, circleReportsDir, timer);
+                        registerFinalizer(
+                                project,
+                                checkstyleTask,
+                                new File(circleReportsDir, "checkstyle"),
+                                timer,
+                                new CheckstyleReportHandler());
                     }
                 });
                 project.getTasks().withType(FindBugs.class, new Action<FindBugs>() {
                     @Override
                     public void execute(FindBugs findbugsTask) {
-                        configureFindbugsTask(project, findbugsTask, circleReportsDir, timer);
+                        registerFinalizer(
+                                project,
+                                findbugsTask,
+                                new File(circleReportsDir, "findbugs"),
+                                timer,
+                                new FindBugsReportHandler());
                     }
                 });
             }
@@ -77,93 +84,5 @@ public class CircleStylePlugin implements Plugin<Project> {
         CircleBuildFinishedAction action = new CircleBuildFinishedAction(container, targetFile, listener);
         rootProject.getGradle().addListener(listener);
         rootProject.getGradle().buildFinished(action);
-    }
-
-    private static void configureCheckstyleTask(
-            final Project project,
-            final Checkstyle checkstyleTask,
-            final String circleReportsDir,
-            final StyleTaskTimer timer) {
-        // Ensure XML output is enabled
-        checkstyleTask.doFirst(new Action<Task>() {
-            @Override
-            public void execute(Task task) {
-                checkstyleTask.getReports().findByName("xml").setEnabled(true);
-            }
-        });
-
-        // Configure the finalizer task
-        CircleStyleFinalizer finalizer = createTask(
-                project.getTasks(),
-                checkstyleTask.getName() + "CircleFinalizer",
-                CircleStyleFinalizer.class);
-        if (finalizer == null) {
-            // Already registered (happens if the user applies us to the root project and subprojects)
-            return;
-        }
-        finalizer.setReportParser(CheckstyleReportHandler.PARSER);
-        finalizer.setStyleTask(checkstyleTask);
-        finalizer.setReporting(checkstyleTask);
-        finalizer.setStyleTaskTimer(timer);
-        finalizer.setTargetFile(new File(
-                new File(circleReportsDir, "checkstyle"),
-                project.getName() + "-" + checkstyleTask.getName() + ".xml"));
-
-        checkstyleTask.finalizedBy(finalizer);
-    }
-
-    private static void configureFindbugsTask(
-            final Project project,
-            final FindBugs findbugsTask,
-            final String circleReportsDir,
-            final StyleTaskTimer timer) {
-        // Ensure XML output is enabled
-        findbugsTask.doFirst(new Action<Task>() {
-            @Override
-            public void execute(Task task) {
-                for (SingleFileReport report : findbugsTask.getReports()) {
-                    report.setEnabled(false);
-                }
-                FindBugsXmlReport xmlReport = (FindBugsXmlReport) findbugsTask.getReports().findByName("xml");
-                xmlReport.setEnabled(true);
-                xmlReport.setWithMessages(true);
-            }
-        });
-
-        // Configure the finalizer task
-        CircleStyleFinalizer finalizer = createTask(
-                project.getTasks(),
-                findbugsTask.getName() + "CircleFinalizer",
-                CircleStyleFinalizer.class);
-        if (finalizer == null) {
-            // Already registered (happens if the user applies us to the root project and subprojects)
-            return;
-        }
-        finalizer.setReportParser(FindBugsReportHandler.PARSER);
-        finalizer.setStyleTask(findbugsTask);
-        finalizer.setReporting(findbugsTask);
-        finalizer.setStyleTaskTimer(timer);
-        finalizer.setTargetFile(new File(
-                new File(circleReportsDir, "findbugs"),
-                project.getName() + "-" + findbugsTask.getName() + ".xml"));
-
-        findbugsTask.finalizedBy(finalizer);
-    }
-
-    private static <T extends Task> T createTask(TaskContainer tasks, String preferredName, Class<T> type) {
-        String name = preferredName;
-        int count = 1;
-        while (true) {
-            try {
-                Task existingTask = tasks.getByName(name);
-                if (type.isInstance(existingTask)) {
-                    return null;
-                }
-            } catch (UnknownTaskException e) {
-                return tasks.create(name, type);
-            }
-            count++;
-            name = preferredName + count;
-        }
     }
 }

--- a/src/main/java/com/palantir/gradle/circlestyle/ReportHandler.java
+++ b/src/main/java/com/palantir/gradle/circlestyle/ReportHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Palantir Technologies, Inc.
+ * Copyright 2018 Palantir Technologies, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,9 +15,16 @@
  */
 package com.palantir.gradle.circlestyle;
 
-import java.io.InputStream;
 import java.util.List;
 
-interface ReportParser {
-    List<Failure> loadFailures(InputStream report);
+import org.gradle.api.Task;
+import org.gradle.api.reporting.ReportContainer;
+import org.gradle.api.reporting.Reporting;
+import org.gradle.api.reporting.SingleFileReport;
+import org.xml.sax.helpers.DefaultHandler;
+
+abstract class ReportHandler<T extends Task & Reporting<? extends ReportContainer<SingleFileReport>>>
+        extends DefaultHandler {
+    public abstract void configureTask(T task);
+    public abstract List<Failure> failures();
 }

--- a/src/main/java/com/palantir/gradle/circlestyle/Tasks.java
+++ b/src/main/java/com/palantir/gradle/circlestyle/Tasks.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2018 Palantir Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.palantir.gradle.circlestyle;
+
+import org.gradle.api.Task;
+import org.gradle.api.UnknownTaskException;
+import org.gradle.api.tasks.TaskContainer;
+
+class Tasks {
+
+    static <T extends Task> T createTask(TaskContainer tasks, String preferredName, Class<T> type) {
+        String name = preferredName;
+        int count = 1;
+        while (true) {
+            try {
+                Task existingTask = tasks.getByName(name);
+                if (type.isInstance(existingTask)) {
+                    return null;
+                }
+            } catch (UnknownTaskException e) {
+                return tasks.create(name, type);
+            }
+            count++;
+            name = preferredName + count;
+        }
+    }
+
+    private Tasks() { }
+}

--- a/src/main/java/com/palantir/gradle/circlestyle/XmlUtils.java
+++ b/src/main/java/com/palantir/gradle/circlestyle/XmlUtils.java
@@ -15,8 +15,12 @@
  */
 package com.palantir.gradle.circlestyle;
 
+import java.io.IOException;
+import java.io.InputStream;
 import java.io.Writer;
 
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.parsers.SAXParserFactory;
 import javax.xml.transform.OutputKeys;
 import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerException;
@@ -25,8 +29,22 @@ import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 
 import org.w3c.dom.Document;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+import org.xml.sax.XMLReader;
 
 class XmlUtils {
+
+    public static <T extends ReportHandler> T parseXml(T handler, InputStream report) {
+        try {
+            XMLReader xmlReader = SAXParserFactory.newInstance().newSAXParser().getXMLReader();
+            xmlReader.setContentHandler(handler);
+            xmlReader.parse(new InputSource(report));
+            return handler;
+        } catch (SAXException | ParserConfigurationException | IOException e) {
+            throw new AssertionError(e);
+        }
+    }
 
     public static Writer write(Writer writer, Document document) throws TransformerException {
         Transformer t = TransformerFactory.newInstance().newTransformer();

--- a/src/test/java/com/palantir/gradle/circlestyle/CheckstyleReportHandlerTests.java
+++ b/src/test/java/com/palantir/gradle/circlestyle/CheckstyleReportHandlerTests.java
@@ -15,9 +15,9 @@
  */
 package com.palantir.gradle.circlestyle;
 
-import static com.palantir.gradle.circlestyle.CheckstyleReportHandler.PARSER;
 import static com.palantir.gradle.circlestyle.TestCommon.CHECKSTYLE_FAILURES;
 import static com.palantir.gradle.circlestyle.TestCommon.testFile;
+import static com.palantir.gradle.circlestyle.XmlUtils.parseXml;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
@@ -29,13 +29,17 @@ public class CheckstyleReportHandlerTests {
 
     @Test
     public void testNoErrors() throws IOException {
-        List<Failure> failures = PARSER.loadFailures(testFile("no-failures-checkstyle.xml").openStream());
+        List<Failure> failures =
+                parseXml(new CheckstyleReportHandler(), testFile("no-failures-checkstyle.xml").openStream())
+                        .failures();
         assertThat(failures).isEmpty();
     }
 
     @Test
     public void testTwoErrors() throws IOException {
-        List<Failure> failures = PARSER.loadFailures(testFile("two-namecheck-failures-checkstyle.xml").openStream());
+        List<Failure> failures =
+                parseXml(new CheckstyleReportHandler(), testFile("two-namecheck-failures-checkstyle.xml").openStream())
+                        .failures();
         assertThat(failures).containsExactlyElementsOf(CHECKSTYLE_FAILURES);
     }
 }

--- a/src/test/java/com/palantir/gradle/circlestyle/CircleStyleFinalizerTests.java
+++ b/src/test/java/com/palantir/gradle/circlestyle/CircleStyleFinalizerTests.java
@@ -59,7 +59,7 @@ public class CircleStyleFinalizerTests {
 
         CircleStyleFinalizer finalizer = (CircleStyleFinalizer) project
                 .task(ImmutableMap.of("type", CircleStyleFinalizer.class), "checkstyleTestCircleFinalizer");
-        finalizer.setReportParser(CheckstyleReportHandler.PARSER);
+        finalizer.setReportHandler(new CheckstyleReportHandler());
         finalizer.setStyleTask(checkstyle);
         finalizer.setReporting(checkstyle);
         finalizer.setStyleTaskTimer(timer);
@@ -87,7 +87,7 @@ public class CircleStyleFinalizerTests {
 
         CircleStyleFinalizer finalizer = (CircleStyleFinalizer) project
                 .task(ImmutableMap.of("type", CircleStyleFinalizer.class), "checkstyleTestCircleFinalizer");
-        finalizer.setReportParser(CheckstyleReportHandler.PARSER);
+        finalizer.setReportHandler(new CheckstyleReportHandler());
         finalizer.setStyleTask(checkstyle);
         finalizer.setReporting(checkstyle);
         finalizer.setStyleTaskTimer(timer);

--- a/src/test/java/com/palantir/gradle/circlestyle/FindBugsReportHandlerTests.java
+++ b/src/test/java/com/palantir/gradle/circlestyle/FindBugsReportHandlerTests.java
@@ -15,9 +15,9 @@
  */
 package com.palantir.gradle.circlestyle;
 
-import static com.palantir.gradle.circlestyle.FindBugsReportHandler.PARSER;
 import static com.palantir.gradle.circlestyle.TestCommon.ROOT;
 import static com.palantir.gradle.circlestyle.TestCommon.testFile;
+import static com.palantir.gradle.circlestyle.XmlUtils.parseXml;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
@@ -50,19 +50,21 @@ public class FindBugsReportHandlerTests {
 
     @Test
     public void testNoErrors() throws IOException {
-        List<Failure> failures = PARSER.loadFailures(testFile("no-errors-findbugs.xml").openStream());
+        List<Failure> failures =
+                parseXml(new FindBugsReportHandler(), testFile("no-errors-findbugs.xml").openStream()).failures();
         assertThat(failures).isEmpty();
     }
 
     @Test
     public void testTwoErrors() throws IOException {
-        List<Failure> failures = PARSER.loadFailures(testFile("two-exit-errors-findbugs.xml").openStream());
+        List<Failure> failures =
+                parseXml(new FindBugsReportHandler(), testFile("two-exit-errors-findbugs.xml").openStream()).failures();
         assertThat(failures).containsExactlyElementsOf(FINDBUGS_FAILURES);
     }
 
     /** @see <a href="https://github.com/palantir/gradle-circle-style/issues/7">Issue 7</a> */
     @Test
     public void testSyntheticSourceLine() throws IOException {
-        PARSER.loadFailures(testFile("synthetic-sourceline-findbugs.xml").openStream());
+        parseXml(new FindBugsReportHandler(), testFile("synthetic-sourceline-findbugs.xml").openStream());
     }
 }


### PR DESCRIPTION
 * Add a common interface for the two ReportHandlers so shared code can be reused.
 * Move Checkstyle/FindBugs–specific task configuration code to the relevant handler
 * Move common XMLReader code to XmlUtils
 * Move finaliser construction/registration code to CircleStyleFinalizer
 * Move generic task creation utility method to Tasks