### PR TITLE
Fix bug handling exceptions with null messages

### DIFF
--- a/src/main/java/com/palantir/gradle/circlestyle/CircleBuildFailureListener.java
+++ b/src/main/java/com/palantir/gradle/circlestyle/CircleBuildFailureListener.java
@@ -63,7 +63,7 @@ class CircleBuildFailureListener implements TaskExecutionListener {
     }
 
     private static String getMessage(Throwable t) {
-        if (t.getMessage().isEmpty()) {
+        if (t.getMessage() == null) {
             return t.getClass().getSimpleName();
         } else {
             return t.getClass().getSimpleName() + ": " + t.getMessage();


### PR DESCRIPTION
Code was erroneously assuming missing messages would be represented by an empty string. They are actually represented by nulls.