### PR TITLE
Place JUnit reports under $CIRCLE_TEST_REPORTS

### DIFF
--- a/src/main/java/com/palantir/gradle/circlestyle/CircleStylePlugin.java
+++ b/src/main/java/com/palantir/gradle/circlestyle/CircleStylePlugin.java
@@ -25,6 +25,7 @@ import org.gradle.api.Project;
 import org.gradle.api.plugins.quality.Checkstyle;
 import org.gradle.api.plugins.quality.FindBugs;
 import org.gradle.api.tasks.compile.JavaCompile;
+import org.gradle.api.tasks.testing.Test;
 
 public class CircleStylePlugin implements Plugin<Project> {
 
@@ -43,6 +44,16 @@ public class CircleStylePlugin implements Plugin<Project> {
         rootProject.allprojects(new Action<Project>() {
             @Override
             public void execute(final Project project) {
+                project.getTasks().withType(Test.class, new Action<Test>() {
+                    @Override
+                    public void execute(Test test) {
+                        File junitReportsDir = new File(circleReportsDir, "junit");
+                        for (String component : test.getPath().substring(1).split(":")) {
+                            junitReportsDir = new File(junitReportsDir, component);
+                        }
+                        test.getReports().getJunitXml().setDestination(junitReportsDir);
+                    }
+                });
                 project.getTasks().withType(Checkstyle.class, new Action<Checkstyle>() {
                     @Override
                     public void execute(Checkstyle checkstyle) {

--- a/src/test/resources/com/palantir/gradle/circlestyle/settings.gradle
+++ b/src/test/resources/com/palantir/gradle/circlestyle/settings.gradle
@@ -1,1 +1,3 @@
 rootProject.name = 'foobar'
+
+include 'subproject'

--- a/src/test/resources/com/palantir/gradle/circlestyle/subproject.gradle
+++ b/src/test/resources/com/palantir/gradle/circlestyle/subproject.gradle
@@ -4,18 +4,6 @@ plugins {
   id 'findbugs'
 }
 
-
-// Apply CircleStylePlugin
-String[] classpath = System.env.TEST_CLASSPATH.split(':')
-URL[] urls = new URL[classpath.length]
-for (int i = 0; i < classpath.length; ++i) {
-  urls[i] = new File(classpath[i]).toURI().toURL()
-}
-ClassLoader testClassLoader = new URLClassLoader(urls, getClass().classLoader)
-def pluginClass = testClassLoader.loadClass('com.palantir.gradle.circlestyle.CircleStylePlugin')
-plugins.apply(pluginClass)
-
-
 repositories {
   mavenCentral()
 }
@@ -35,7 +23,7 @@ tasks.withType(Checkstyle) {
 }
 
 findbugs {
-  includeFilter = file("config/findbugs/findbugsIncludeFilter.xml")
+  includeFilter = rootProject.file("config/findbugs/findbugsIncludeFilter.xml")
 }
 
 tasks.withType(FindBugs) {

--- a/src/test/resources/com/palantir/gradle/circlestyle/tested-class
+++ b/src/test/resources/com/palantir/gradle/circlestyle/tested-class
@@ -1,0 +1,9 @@
+package com.example;
+
+public class MyClass {
+    public static int doubleIt(int input) {
+        return 4;
+    }
+    
+    private MyClass() { }
+}

--- a/src/test/resources/com/palantir/gradle/circlestyle/tested-class-tests
+++ b/src/test/resources/com/palantir/gradle/circlestyle/tested-class-tests
@@ -1,0 +1,20 @@
+package com.example;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+
+public class MyClassTests {
+
+    @Test
+    public void doublesTwo() {
+        int result = MyClass.doubleIt(2);
+        assertThat(result).isEqualTo(4);
+    }
+    
+    @Test
+    public void doublesThree() {
+        int result = MyClass.doubleIt(3);
+        assertThat(result).isEqualTo(6);
+    }
+}


### PR DESCRIPTION
Currently, authors need to add [janky post-test commands](https://circleci.com/docs/1.0/test-metadata/#gradle-junit-test-results) to their circle.yml to copy JUnit reports to the location CircleCI expects to find them. We can do that automatically.